### PR TITLE
Fix for the none values in evaluate function

### DIFF
--- a/BinPy/Algorithms/AnalogFormulas.py
+++ b/BinPy/Algorithms/AnalogFormulas.py
@@ -18,7 +18,7 @@ class OhmsLaw:
         DictKeys: 'i', 'v', 'r', 'p'
         '''
         values = [i, v, r, p]
-        if (any(j < 0) for j in values):
+        if (any((j != None and j < 0) for j in values)):
             raise Exception('enter positive values')
         else:
             if not p:


### PR DESCRIPTION
Since the merged commit https://github.com/BinPy/BinPy/commit/d5f6548a5763bd19132299c47bbc3fc874fcb728 , the function evaluate() no longer worked for positive values as the None type is considered as negative.

Please review this request
