### PR TITLE
Name Conflict in class attribute and class variable and method - inputs

### DIFF
--- a/BinPy/Gates/gates.py
+++ b/BinPy/Gates/gates.py
@@ -11,7 +11,7 @@ class GATES:
 		self.history_active = 0 # Ignore history for first computation
 		self.outputType = 0 # 1->output goes to a connector class
 		self.result = 0 #To store the result
-		self.outputConnector = None #Valid only is outputType = 1
+		self.outputConnector = None #Valid only if outputType = 1
 		self.inputs = inputs[:] # Set the inputs
 		self.history_inputs = [] # Save a copy of the inputs
 		self.__updateConnections(self.inputs)
@@ -60,9 +60,14 @@ class GATES:
 
 		self.trigger()
 
-	def inputs(self):
-
-		return self.inputs
+	def getInputStates(self):
+                input_states = []
+                for i in self.inputs:
+                        if isinstance(i, Connector):
+                                input_states.append(self.inputs[i].state)
+                        else:
+                                input_states.append(self.inputs[i])
+		return input_states
 
 	def _updateResult(self,value):
 		


### PR DESCRIPTION
Changed the name of the function to getInputStates()
Changed its functionality to return the states of the input connectors rather than the connectors themselves
