### PR TITLE
addition of ic-7483(4 bit full adder)

### DIFF
--- a/BinPy/ic/series_7400.py
+++ b/BinPy/ic/series_7400.py
@@ -696,7 +696,6 @@ class IC_74260(Base_14pin):
         else:
             print "Ground and VCC pins have not been configured correctly"
 
-
 ######## IC's with 5 pins #################################
 
 class IC_741G00(Base_5pin):

--- a/BinPy/ic/series_7400.py
+++ b/BinPy/ic/series_7400.py
@@ -696,6 +696,7 @@ class IC_74260(Base_14pin):
         else:
             print "Ground and VCC pins have not been configured correctly"
 
+
 ######## IC's with 5 pins #################################
 
 class IC_741G00(Base_5pin):
@@ -1056,5 +1057,44 @@ class IC_74133(Base_16pin):
             return output
         else:
             print "Ground and VCC pins have not been configured correctly"
+
+class IC_7483(Base_16pin):
+    """
+    This is a 4-bit full adder with fast carry
+    """
+
+    #Datasheet here, http://www.skot9000.com/ttl/datasheets/83.pdf
+
+    def __init__(self):
+        self.pins = [None,0,None,0,0,0,None,0,0,None,0,0,0,0,None,None,0]
+
+    def run(self):
+        output = {}
+
+        output[9] = XOR(self.pins[10],self.pins[11],self.pins[13]).output()
+
+        carry = OR(AND(self.pins[13],XOR(self.pins[10],self.pins[11]).output()).output(),
+                   AND(self.pins[10],self.pins[11]).output()).output()
+
+        output[6] = XOR(self.pins[8],self.pins[7],carry).output()
+
+	carry = OR(AND(carry,XOR(self.pins[8],self.pins[7]).output()).output(),
+                   AND(self.pins[8],self.pins[7]).output()).output()
+
+        output[2] = XOR(self.pins[3],self.pins[4],carry).output()
+
+        carry = OR(AND(carry,XOR(self.pins[3],self.pins[4]).output()).output(),
+                   AND(self.pins[3],self.pins[4]).output()).output()
+
+        output[15] = XOR(self.pins[1],self.pins[16],carry).output()
+
+        output[14] = OR(AND(carry,XOR(self.pins[1],self.pins[16]).output()).output(),
+                        AND(self.pins[1],self.pins[16]).output()).output()
+
+        if self.pins[12] == 0 and self.pins[5] == 1:
+            return output
+        else:
+            print "Ground and VCC pins have not been configured correctly"
+
 
 

--- a/BinPy/ic/series_7400.py
+++ b/BinPy/ic/series_7400.py
@@ -1095,5 +1095,3 @@ class IC_7483(Base_16pin):
         else:
             print "Ground and VCC pins have not been configured correctly"
 
-
-

--- a/BinPy/tests/tests.py
+++ b/BinPy/tests/tests.py
@@ -470,7 +470,7 @@ def test_IC_74133():
         assert False
 
 def test_IC_7483():
-    testIC = IC_74133()
+    testIC = IC_7483()
     p = {1:1,3:0,4:0,5:1,7:1,8:0,10:1,11:1,12:0,13:1,16:1}
     testIC.setIC(p)
     q = {9:1,2:1,14:1,6:0,15:0}

--- a/BinPy/tests/tests.py
+++ b/BinPy/tests/tests.py
@@ -468,6 +468,14 @@ def test_IC_74133():
     q = {9:1}
     if q!=testIC.run():
         assert False
+
+def test_IC_7483():
+    testIC = IC_74133()
+    p = {1:1,3:0,4:0,5:1,7:1,8:0,10:1,11:1,12:0,13:1,16:1}
+    testIC.setIC(p)
+    q = {9:1,2:1,14:1,6:0,15:0}
+    if q!=testIC.run():
+        assert False
         
 def test_IC_4081():
     testIC = IC_4081()


### PR DESCRIPTION
i have also used a temporary carry variable to increase the readability of the code but no temporary variables are used in any other ICs , so i was wondering if it would be better to remove the temporary variable.
