### PR TITLE
Decoder class had a small problem

### DIFF
--- a/BinPy/Combinational/combinational.py
+++ b/BinPy/Combinational/combinational.py
@@ -305,7 +305,9 @@ class Decoder(GATES):
         for i in self.inputs:
             if isinstance(i, Connector):
                 bstr = bstr + str(i.state)
-            else:
+            elif type(i) == bool:
+                bstr = bstr + str(int(i))
+            elif type(i) == int:
                 bstr = bstr + str(i)
         out[int(bstr, 2)] = 1
         self._updateResult(out)


### PR DESCRIPTION
Suppose the following code:

```
d = Decoder(False, True)
```

It shouldn't fail. However I was getting the following:

```
Traceback (most recent call last):
  File "test.py", line 5, in <module>
    print(d.output())
  File "/home/petermlm/Documents/GSoC/BinPy/BinPy/Gates/gates.py", line 99, in output
    self.trigger()
  File "/home/petermlm/Documents/GSoC/BinPy/BinPy/Combinational/combinational.py", line 310, in trigger
    out[int(bstr, 2)] = 1
ValueError: invalid literal for int() with base 2: 'FalseTrue'
```

When I had a look at the trigger function of Decoder I noticed that I had to make the small change in this pull request.

Is this right? Should it work like this, taking booleans as inputs instead of integers?
