### PR TITLE
Added Truthtable method for ICs

### DIFF
--- a/BinPy/examples/truthtable.py
+++ b/BinPy/examples/truthtable.py
@@ -1,0 +1,11 @@
+from BinPy import *
+
+
+print ('Initialising IC_4001:\n-- t = IC4001()\n')
+t=IC_4001()
+print ('\nGiving a pinConfig in the form of a dict:')
+p = {'i':[13,12],'o':[11]}
+print ('--p =')+(str(p))
+print ('\nRunning the truthtable method:\n-- t.truthtable(p)\n')
+
+t.truthtable(p)

--- a/BinPy/ic/base.py
+++ b/BinPy/ic/base.py
@@ -123,6 +123,57 @@ class IC:
                 raise Exception("ERROR: IC not supported")
         except:
             print("ERROR: Draw Failed - " + sys.exc_info()[1].args[0])
+    
+    def truthtable(self, pinConfig):
+
+        if isinstance(self, Base_14pin): a={1:0, 2:0, 3:0, 4:0, 5:0, 6:0, 7:0, 8:0, 9:0, 10:0, 11:0, 12:0, 13:0, 14:1}
+        elif isinstance(self, Base_16pin): a={1:0, 2:0, 3:0, 4:0, 5:0, 6:0, 7:0, 8:0, 9:0, 10:0, 11:0, 12:0, 13:0, 14:1, 15:0, 16:1}
+        elif isinstance(self, Base_5pin): a={1:0, 2:0, 3:0, 4:0, 5:1}
+        
+        i = pinConfig['i']
+        o = pinConfig['o']
+        
+        print ("   "+"INPUTS"+(" " * (5 * len(i) - 4))+"|"+"OUTPUTS")
+        print ("   "+"-" * (5 * len(i)+ 2)+ "|"+"-" * (5 * len(o)))
+        stdout.write("   ")
+        for j in range(len(i)):
+            if len(str(i[j])) == 1: print ("   "+ str(i[j]), end=" ")
+            elif len(str(i[j])) == 2: print ("  "+ str(i[j]), end=" ") 
+        stdout.write("  |")
+        for j in range(len(o)):
+            if len(str(o[j])) == 1: print ("   "+ str(o[j]), end=" ")
+            elif len(str(o[j])) == 2: print ("  "+ str(o[j]), end=" ")        
+        print ("\n   "+ "-" * (5 * len(i) + 2)+"|"+ "-" * (5 * len(o)))
+        
+        def f(l):
+        
+            if len(l) == 1:
+                for q in range(2):
+                    a[l[0]] = q
+                    inputlist = []
+                
+                    for u in range(len(i)):
+                        inputlist.append(a[i[u]])
+                    
+                    if hasattr(self,'invalidlist'):    
+                        if inputlist in self.invalidlist:
+                            break    
+                    
+                    
+                    self.setIC(a)
+                    outpins = self.run()
+                    
+                    stdout.write("   ")
+                    for u in range (len(i)): print ("   "+ str(a[i[u]]), end=" ")
+                    stdout.write("  |")
+                    for u in range(len(o)): print ("   "+ str(outpins[o[u]]), end=" ")
+                    print ("")    
+            
+            else:
+                for q in range(2):
+                    a[l[0]] = q
+                    f(l[1:])
+        f(i)
 
 
 class Base_5pin(IC):

--- a/BinPy/ic/series_7400.py
+++ b/BinPy/ic/series_7400.py
@@ -1898,14 +1898,7 @@ class IC_7442(Base_16pin):
             0,
             0,
             0]
-
-    def run(self):
-        output = {}
-        inputlist = []
-        for i in range(12, 16, 1):
-            inputlist.append(self.pins[i])
-
-        invalidlist = [
+        self.invalidlist = [
             [
                 1, 0, 1, 0], [
                 1, 0, 1, 1], [
@@ -1913,8 +1906,16 @@ class IC_7442(Base_16pin):
                 1, 1, 0, 1], [
                 1, 1, 1, 0], [
                 1, 1, 1, 1]]
+            
 
-        if inputlist in invalidlist:
+    def run(self):
+        output = {}
+        inputlist = []
+        for i in range(12, 16, 1):
+            inputlist.append(self.pins[i])
+
+
+        if inputlist in self.invalidlist:
             raise Exception("ERROR: Invalid BCD number")
 
         output[1] = NAND(NOT(self.pins[15]).output(),
@@ -1995,6 +1996,14 @@ class IC_7443(Base_16pin):
             0,
             0,
             0]
+        self.invalidlist = [
+                [0, 0, 0, 0], 
+                [0, 0, 0, 1], [
+                0, 0, 1, 0], [
+                1, 1, 0, 1], [
+                1, 1, 1, 0], [
+                1, 1, 1, 1]]       
+            
 
     def run(self):
         output = {}
@@ -2002,16 +2011,8 @@ class IC_7443(Base_16pin):
         for i in range(12, 16, 1):
             inputlist.append(self.pins[i])
 
-        invalidlist = [
-            [
-                0, 0, 0, 0], [
-                0, 0, 0, 1], [
-                0, 0, 1, 0], [
-                1, 1, 0, 1], [
-                1, 1, 1, 0], [
-                1, 1, 1, 1]]
 
-        if inputlist in invalidlist:
+        if inputlist in self.invalidlist:
             raise Exception("ERROR: Invalid Pin configuration")
 
         output[1] = NAND(
@@ -2087,6 +2088,13 @@ class IC_7444(Base_16pin):
             0,
             0,
             0]
+        self.invalidlist = [ [0, 0, 0, 0],
+                             [0, 0, 0, 1],
+                             [0, 0, 1, 1],
+                             [1, 0, 0, 0],
+                             [1, 0, 0, 1],
+                             [1, 0, 1, 1]]
+            
 
     def run(self):
         output = {}
@@ -2094,16 +2102,7 @@ class IC_7444(Base_16pin):
         for i in range(12, 16, 1):
             inputlist.append(self.pins[i])
 
-        invalidlist = [
-            [
-                0, 0, 0, 0], [
-                0, 0, 0, 1], [
-                0, 0, 1, 1], [
-                1, 0, 0, 0], [
-                1, 0, 0, 1], [
-                1, 0, 1, 1]]
-
-        if inputlist in invalidlist:
+        if inputlist in self.invalidlist:
             raise Exception("ERROR: Invalid Pin configuration")
 
         output[1] = NAND(NOT(self.pins[15]).output(),
@@ -2177,6 +2176,14 @@ class IC_7445(Base_16pin):
             0,
             0,
             0]
+        
+        self.invalidlist = [
+                            [1, 0, 1, 0],
+                            [1, 0, 1, 1], 
+                            [1, 1, 0, 0],
+                            [1, 1, 0, 1],
+                            [1, 1, 1, 0],
+                            [1, 1, 1, 1]]            
 
     def run(self):
         output = {}
@@ -2184,16 +2191,7 @@ class IC_7445(Base_16pin):
         for i in range(12, 16, 1):
             inputlist.append(self.pins[i])
 
-        invalidlist = [
-            [
-                1, 0, 1, 0], [
-                1, 0, 1, 1], [
-                1, 1, 0, 0], [
-                1, 1, 0, 1], [
-                1, 1, 1, 0], [
-                1, 1, 1, 1]]
-
-        if inputlist in invalidlist:
+        if inputlist in self.invalidlist:
             raise Exception("ERROR: Invalid Pin configuration")
 
         output[1] = NAND(NOT(self.pins[15]).output(),


### PR DESCRIPTION
'Truthtable' method when applied can give the user a truthtable corresponding to the set of inputs and outputs pins specified by the user for a defined IC.
**Note:** The input( 'i' ) and output( 'o' ) pins list should contain the pin nos. strictly in order of MSB...to...LSB. Also if the IC contains enable pins ,they should be preceding the data-input pins in the input list ( 'i' ).
**Note:** This method doesnt work perfectly for ICs taking in inputs like (0,0,0,1,0,0,0,0),(0,0,0,0,1,0,0,0),(0,0,0,0,0,1,0,0) etc. (eg. Priority Encoder IC 74147, IC74148) 

```
>>>t=IC_4001()
>>>p = {'i':[13,12],'o':[11]}
>>>t.truthtable(p)
   INPUTS      |OUTPUTS
   ------------|-----
     13   12   |  11 
   ------------|-----
      0    0   |   1 
      0    1   |   0 
      1    0   |   0 
      1    1   |   0 
```

PS: This is definitely not a elegant piece of code. So please leave your suggestions down in the comments .
