### PR TITLE
Add tests to check support for python 2.6 and 3.2 as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
+  - 2.6
   - 2.7
+  - 3.2
   - 3.3
   - pypy
 


### PR DESCRIPTION
If we can, we should support 2.6 and 3.2. Some linux distros still come with 3.2.
