### PR TITLE
Tests Do Not Exit Upon Error - Fix for #239

### DIFF
--- a/test_travis.sh
+++ b/test_travis.sh
@@ -1,38 +1,46 @@
 #! /usr/bin/env bash
-set -e
-pep8 --ignore=E501 ./
-nosetests
-nosetests3
-cd BinPy/tests/
-nosetests gates_tests.py
-nosetests combinational_tests.py
-nosetests operations_tests.py
-nosetests sequential_tests.py
-nosetests counters_tests.py
-nosetests series_4000_tests.py
-nosetests series_7400_tests.py
-nosetests source_tests.py
-nosetests sequential_ic_tests.py
-nosetests registers_tests.py
-nosetests tree_tests.py
-nosetests print_tests.py
-nosetests expr_tests.py
-nosetests analog_devices_tests.py
-nosetests analog_source_tests.py
-nosetests test_makebooleanfunction.py
-nosetests3 gates_tests.py
-nosetests3 combinational_tests.py
-nosetests3 operations_tests.py
-nosetests3 sequential_tests.py
-nosetests3 counters_tests.py
-nosetests3 series_4000_tests.py
-nosetests3 series_7400_tests.py
-nosetests3 source_tests.py
-nosetests3 sequential_ic_tests.py
-nosetests3 registers_tests.py
-nosetests3 tree_tests.py
-nosetests3 print_tests.py
-nosetests3 expr_tests.py
-nosetests3 analog_devices_tests.py
-nosetests3 analog_source_tests.py
-nosetests3 test_makebooleanfunction.py
+status_code=$?
+function chk()
+{ 
+    let "status_code=$status_code||$?";
+}
+
+pep8 --ignore=E501 ./; chk;
+nosetests; chk;
+nosetests3; chk;
+cd BinPy/tests/; chk;
+nosetests gates_tests.py; chk;
+nosetests combinational_tests.py; chk;
+nosetests operations_tests.py; chk;
+nosetests sequential_tests.py; chk;
+nosetests counters_tests.py; chk;
+nosetests series_4000_tests.py; chk;
+nosetests series_7400_tests.py; chk;
+nosetests source_tests.py; chk;
+nosetests sequential_ic_tests.py; chk;
+nosetests registers_tests.py; chk;
+nosetests tree_tests.py; chk;
+nosetests print_tests.py; chk;
+nosetests expr_tests.py; chk;
+nosetests analog_devices_tests.py; chk;
+nosetests analog_source_tests.py; chk;
+nosetests test_makebooleanfunction.py; chk;
+nosetests3 gates_tests.py; chk;
+nosetests3 combinational_tests.py; chk;
+nosetests3 operations_tests.py; chk;
+nosetests3 sequential_tests.py; chk;
+nosetests3 counters_tests.py; chk;
+nosetests3 series_4000_tests.py; chk;
+nosetests3 series_7400_tests.py; chk;
+nosetests3 source_tests.py; chk;
+nosetests3 sequential_ic_tests.py; chk;
+nosetests3 registers_tests.py; chk;
+nosetests3 tree_tests.py; chk;
+nosetests3 print_tests.py; chk;
+nosetests3 expr_tests.py; chk;
+nosetests3 analog_devices_tests.py; chk;
+nosetests3 analog_source_tests.py; chk;
+nosetests3 test_makebooleanfunction.py; chk;
+
+exit $status_code;
+


### PR DESCRIPTION
Included a error checking variable to check and persist error if even one test fails while still executing all the commands ....
