### PR TITLE
Nosetests - include nopep8 support

### DIFF
--- a/test_travis_offline.sh
+++ b/test_travis_offline.sh
@@ -4,46 +4,55 @@ function chk()
 { 
     let "status_code=$status_code||$?";
 }
+if [ "$1" != "nopep8" ] && [ "$2" != "nopep8" ];
+    then
+    {
+        echo "Starting PEP8 Test";
+        pep8 --exclude="build/*" --ignore=E501 ./; chk;
+        echo "PEP8 Test ended";
+    }
+else
+    echo "PEP8 Test skipped";
 
-pep8 --exclude="build/*" --ignore=E501 ./; chk;
+fi
 
 cd BinPy/tests/; chk;
-nosetests; chk;
-nosetests3; chk;
-nosetests gates_tests.py; chk;
-nosetests combinational_tests.py; chk;
-nosetests operations_tests.py; chk;
-nosetests sequential_tests.py; chk;
-nosetests counters_tests.py; chk;
-nosetests series_4000_tests.py; chk;
-nosetests series_7400_tests.py; chk;
-nosetests source_tests.py; chk;
-nosetests sequential_ic_tests.py; chk;
-nosetests registers_tests.py; chk;
-nosetests tree_tests.py; chk;
-nosetests print_tests.py; chk;
-nosetests expr_tests.py; chk;
-nosetests analog_devices_tests.py; chk;
-nosetests analog_source_tests.py; chk;
-nosetests test_makebooleanfunction.py; chk;
-nosetests test_analog_converters_buffers.py; chk;
-nosetests3 gates_tests.py; chk;
-nosetests3 combinational_tests.py; chk;
-nosetests3 operations_tests.py; chk;
-nosetests3 sequential_tests.py; chk;
-nosetests3 counters_tests.py; chk;
-nosetests3 series_4000_tests.py; chk;
-nosetests3 series_7400_tests.py; chk;
-nosetests3 source_tests.py; chk;
-nosetests3 sequential_ic_tests.py; chk;
-nosetests3 registers_tests.py; chk;
-nosetests3 tree_tests.py; chk;
-nosetests3 print_tests.py; chk;
-nosetests3 expr_tests.py; chk;
-nosetests3 analog_devices_tests.py; chk;
-nosetests3 analog_source_tests.py; chk;
-nosetests3 test_makebooleanfunction.py; chk;
-nosetests3 test_analog_converters_buffers.py; chk;
-nosetests3  --with-coverage --cover-package=BinPy
+nosetests -v; chk;
+nosetests3 -v -v; chk;
+nosetests -v gates_tests.py; chk;
+nosetests -v combinational_tests.py; chk;
+nosetests -v operations_tests.py; chk;
+nosetests -v sequential_tests.py; chk;
+nosetests -v counters_tests.py; chk;
+nosetests -v series_4000_tests.py; chk;
+nosetests -v series_7400_tests.py; chk;
+nosetests -v source_tests.py; chk;
+nosetests -v sequential_ic_tests.py; chk;
+nosetests -v registers_tests.py; chk;
+nosetests -v tree_tests.py; chk;
+nosetests -v print_tests.py; chk;
+nosetests -v expr_tests.py; chk;
+nosetests -v analog_devices_tests.py; chk;
+nosetests -v analog_source_tests.py; chk;
+nosetests -v test_makebooleanfunction.py; chk;
+nosetests -v test_analog_converters_buffers.py; chk;
+nosetests3 -v gates_tests.py; chk;
+nosetests3 -v combinational_tests.py; chk;
+nosetests3 -v operations_tests.py; chk;
+nosetests3 -v sequential_tests.py; chk;
+nosetests3 -v counters_tests.py; chk;
+nosetests3 -v series_4000_tests.py; chk;
+nosetests3 -v series_7400_tests.py; chk;
+nosetests3 -v source_tests.py; chk;
+nosetests3 -v sequential_ic_tests.py; chk;
+nosetests3 -v registers_tests.py; chk;
+nosetests3 -v tree_tests.py; chk;
+nosetests3 -v print_tests.py; chk;
+nosetests3 -v expr_tests.py; chk;
+nosetests3 -v analog_devices_tests.py; chk;
+nosetests3 -v analog_source_tests.py; chk;
+nosetests3 -v test_makebooleanfunction.py; chk;
+nosetests3 -v test_analog_converters_buffers.py; chk;
+nosetests3 -v  --with-coverage --cover-package=BinPy
 exit $status_code;
 


### PR DESCRIPTION
- Included support for nopep8 argument to help avoid delay in testing.

`bash test_travis_offline.sh nopep8` will run all tests except the pep8 check.
- Re-introduce verbosity in offline tests alone to assist in debugging.
