### PR TITLE
Proper Error Message

### DIFF
--- a/BinPy/algorithms/AnalogFormulas.py
+++ b/BinPy/algorithms/AnalogFormulas.py
@@ -22,6 +22,10 @@ class OhmsLaw:
         DictKeys: 'i', 'v', 'r', 'p'
         '''
         values = [i, v, r, p]
+        
+        if sum(j is None for j in values)>2:
+            raise Exception('Atleast two parameters required')
+    
         if (any((j is not None and j < 0) for j in values)):
             raise Exception('enter positive values')
         else:
@@ -71,6 +75,10 @@ class OhmsLaw_AC:
         DictKeys: 'i', 'v', 'z', 'p','c'
         '''
         values = [i, v, z, p, c]
+
+        if sum(j is None for j in values)>3:
+            raise Exception('Atleast three parameters required')
+        
         if (any((j is not None and j < 0) for j in values)):
             raise Exception('enter positive values')
         else:


### PR DESCRIPTION
Displays proper error message when insufficient number of parameters is given in the evaluate function of OhmsLaw or OhmsLaw_AC.
