### PR TITLE
modified invalid min/max terms error

### DIFF
--- a/BinPy/algorithms/makebooleanfunction.py
+++ b/BinPy/algorithms/makebooleanfunction.py
@@ -1,5 +1,5 @@
-from BinPy.algorithms.ExpressionConvert import *
-from BinPy.algorithms.QuineMcCluskey import *
+from BinPy.Algorithms.ExpressionConvert import *
+from BinPy.Algorithms.QuineMcCluskey import *
 import sys
 
 
@@ -26,13 +26,13 @@ def make_boolean(vars, min_max, dont_care=None, **kwargs):
         if 'minterms' in kwargs:
             if kwargs['minterms'] is True:
                 ones = min_max
-                if ones[-1] >= pow(2, len(vars)):
+                if any(term >= pow(2, len(vars)) for term in ones):
                     raise Exception("Error: Invalid minterms")
                 break
         elif 'maxterms' in kwargs:
             if kwargs['maxterms'] is True:
                 zeros = min_max
-                if zeros[-1] >= pow(2, len(vars)):
+                if any(term >= pow(2, len(vars)) for term in zeros):
                     raise Exception("Error: Invalid maxterms")
                 for i in range(pow(2, len(vars))):
                     if i not in zeros:


### PR DESCRIPTION
I found that on giving the following input - 

``` python
>>> from BinPy import *
>>> make_boolean(['A', 'B', 'C'], [1, 14, 7], minterms=True)
```

The following output comes - 

``` python
('((A AND (NOT B) AND (NOT C)) OR (A AND B AND C) OR ((NOT A) AND B AND C))', 'OR(AND(A, NOT(B), NOT(C)), AND(A, B, C), AND(NOT(A), B, C))')
```

Which is ambiguous. I know the input itself is flawed but I think on giving such input error should be displayed and not an ambiguous result.
Please look into it.
If you find the change reasonable, kindly inform me so that I will edit the tests as well.
