### PR TITLE
docs: Fix a few typos

### DIFF
--- a/BinPy/analog/buffers.py
+++ b/BinPy/analog/buffers.py
@@ -149,7 +149,7 @@ class AnalogBuffer(object):
 
     def set_inouts(self, inputs, outputs):
         """
-        Set the inputs and ouputs to be linked with the inputs and the outputs of the buffer bank module
+        Set the inputs and outputs to be linked with the inputs and the outputs of the buffer bank module
         """
         with AutoUpdater._lock:
             if (inputs.width != outputs.width):

--- a/BinPy/analog/sig_gen.py
+++ b/BinPy/analog/sig_gen.py
@@ -331,7 +331,7 @@ class SignalGenerator(threading.Thread):
         """
         Set the frequency range of the output. Use ranges within
         SignalGenerator.FREQ_MAX and SignalGenerator.FREQ_MIN.
-        Specify input as a tuple containg the LOW followed by the
+        Specify input as a tuple containing the LOW followed by the
         HIGH frequency limits. Preferably use the predefined constant
         dictionary SignalGenerator.FREQ_RANGE
 
@@ -391,7 +391,7 @@ class SignalGenerator(threading.Thread):
 
     def set_frequency_exact(self, frequency):
         """
-        Set the given frequency as the freqency of the output. The current range will be varied based on the value.
+        Set the given frequency as the frequency of the output. The current range will be varied based on the value.
         """
         if (type(frequency) not in [int, float]):
             raise TypeError(

--- a/BinPy/connectors/connector.py
+++ b/BinPy/connectors/connector.py
@@ -377,7 +377,7 @@ class Bus(object):
     def set_logic_all(self, *values):
         """
         Sets the passed word to the connectors in 4 ways
-        1. word as an int representation of the bits of bus ( trucated to digital voltage levels ) : 4 ( 0100 )
+        1. word as an int representation of the bits of bus ( truncated to digital voltage levels ) : 4 ( 0100 )
         2. word as a binary literal : '0b0001' or '1111'
         3. A packed or unpacked list of  connector objects or
            a packed or unpacked list of integer binary values. : [ a, b, c, d ] or *[ 1, 0, None, 1]

--- a/BinPy/connectors/linker.py
+++ b/BinPy/connectors/linker.py
@@ -9,7 +9,7 @@ class AutoUpdater(threading.Thread):
 
     """
     AutoUpdater class provides a collection of static methods for linking BinPy connections primitives Bus and Connector.
-    Note that since Bus is a collecion of Connectors, AutoUpdater essentially binds together a network of linked Connectors.
+    Note that since Bus is a collection of Connectors, AutoUpdater essentially binds together a network of linked Connectors.
 
     Use this class to provide automatic state propagation between modules ( with Bus input / output )
 
@@ -326,7 +326,7 @@ connections_updater_thread.start()
 class BinPyIndexer(object):
 
     """
-    The BnPy Indexer is a indexing and inventory listing servic to bind a unique index and store them as key:value
+    The BnPy Indexer is a indexing and inventory listing service to bind a unique index and store them as key:value
 
     This makes it easier to debug connections.
 

--- a/BinPy/docs/ic/pin_class.md
+++ b/BinPy/docs/ic/pin_class.md
@@ -94,9 +94,9 @@ Create an empty output dictionary
 ```
 Define the output equations for the output pins using overloaded operators of logic instance
 
-Note that the pin instance ( say `self.pins[i]` ) retuns a logic instance initiated with its value:
+Note that the pin instance ( say `self.pins[i]` ) returns a logic instance initiated with its value:
 
-i.e `self.pins[1]()` retuns a logic instance equivalent to `logic(self.pins[1].value)`
+i.e `self.pins[1]()` returns a logic instance equivalent to `logic(self.pins[1].value)`
 
 i.e if `self.pins[1]` has a `value` of `1`, it returns `logic(1)`
 

--- a/BinPy/examples/source/Gates/Connector.py
+++ b/BinPy/examples/source/Gates/Connector.py
@@ -24,7 +24,7 @@ print (conn.state)
 
 # In[3]:
 
-# Calling the connector intance returns its state
+# Calling the connector instance returns its state
 
 print (conn())
 

--- a/BinPy/examples/source/algorithms/expression_convert_example.py
+++ b/BinPy/examples/source/algorithms/expression_convert_example.py
@@ -3,7 +3,7 @@
 
 # <headingcell level=2>
 
-# An example to demostrate functionality of ExpressionConvert.py
+# An example to demonstrate functionality of ExpressionConvert.py
 
 # <codecell>
 
@@ -36,7 +36,7 @@ print(converted)
 
 # <codecell>
 
-# Obtained Expression with two input gate contraint
+# Obtained Expression with two input gate constraint
 converted2 = convertExpression(expr, two_input=1)
 
 print(converted2)
@@ -55,7 +55,7 @@ print(converted)
 
 # <codecell>
 
-# Obtained Expression with two input gate contraint
+# Obtained Expression with two input gate constraint
 converted2 = convertExpression(expr, two_input=1)
 
 print(converted2)

--- a/BinPy/examples/source/algorithms/make_boolean_function_example.py
+++ b/BinPy/examples/source/algorithms/make_boolean_function_example.py
@@ -3,7 +3,7 @@
 
 # <headingcell level=2>
 
-# An example to demostrate the usage of make boolean function.
+# An example to demonstrate the usage of make boolean function.
 
 # <codecell>
 

--- a/BinPy/examples/source/analog/Analog Signal Generators.py
+++ b/BinPy/examples/source/analog/Analog Signal Generators.py
@@ -28,7 +28,7 @@ sig1.kill()
 
 # <codecell>
 
-# AM Signal generation using 2 intances of Signal Generator modules.
+# AM Signal generation using 2 instances of Signal Generator modules.
 
 import numpy as np
 %matplotlib inline

--- a/BinPy/examples/source/connectors/Connector.py
+++ b/BinPy/examples/source/connectors/Connector.py
@@ -24,7 +24,7 @@ print (conn.state)
 
 # <codecell>
 
-# Calling the connector intance returns its state
+# Calling the connector instance returns its state
 
 print (conn())
 

--- a/BinPy/examples/source/ic/Series_4000/IC4000.py
+++ b/BinPy/examples/source/ic/Series_4000/IC4000.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {3: 1, 4: 1, 5: 1, 7: 0, 8: 1, 11: 0, 12: 0, 13: 0, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_4000/IC4001.py
+++ b/BinPy/examples/source/ic/Series_4000/IC4001.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 0, 2: 0, 5: 0, 6: 1, 7: 0, 8: 1, 9: 0, 12: 1, 13: 1, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_4000/IC4002.py
+++ b/BinPy/examples/source/ic/Series_4000/IC4002.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {2: 0, 3: 0, 4: 0, 5: 0, 7: 0, 9: 1, 10: 1, 11: 1, 12: 1, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_4000/IC4011.py
+++ b/BinPy/examples/source/ic/Series_4000/IC4011.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 0, 2: 0, 5: 0, 6: 1, 7: 0, 8: 1, 9: 0, 12: 1, 13: 1, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_4000/IC4012.py
+++ b/BinPy/examples/source/ic/Series_4000/IC4012.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {2: 0, 3: 1, 4: 0, 5: 1, 7: 0, 9: 1, 10: 1, 11: 1, 12: 1, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_4000/IC4023.py
+++ b/BinPy/examples/source/ic/Series_4000/IC4023.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 1, 2: 1, 3: 0, 4: 0, 5: 0, 7: 0, 8: 1, 11: 0, 12: 1, 13: 1, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_4000/IC4025.py
+++ b/BinPy/examples/source/ic/Series_4000/IC4025.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 1, 2: 1, 3: 0, 4: 0, 5: 0, 7: 0, 8: 1, 11: 0, 12: 1, 13: 1, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_4000/IC4068.py
+++ b/BinPy/examples/source/ic/Series_4000/IC4068.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {2: 1, 3: 1, 4: 0, 5: 1, 7: 0, 9: 1, 10: 0, 11: 1, 12: 1, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0}) -- \n
 

--- a/BinPy/examples/source/ic/Series_4000/IC4069.py
+++ b/BinPy/examples/source/ic/Series_4000/IC4069.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {2: 0, 3: 1, 4: 0, 5: 1, 7: 0, 9: 1, 10: 1, 11: 1, 12: 1, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0}) -- \n
 

--- a/BinPy/examples/source/ic/Series_4000/IC4070.py
+++ b/BinPy/examples/source/ic/Series_4000/IC4070.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {2: 0, 3: 1, 4: 0, 5: 1, 7: 0, 9: 1, 10: 1, 11: 1, 12: 1, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_4000/IC4071.py
+++ b/BinPy/examples/source/ic/Series_4000/IC4071.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {2: 0, 3: 1, 4: 0, 5: 1, 7: 0, 9: 1, 10: 1, 11: 1, 12: 1, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0}) -- \n
 

--- a/BinPy/examples/source/ic/Series_4000/IC4072.py
+++ b/BinPy/examples/source/ic/Series_4000/IC4072.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {2: 0, 3: 1, 4: 0, 5: 1, 7: 0, 9: 1, 10: 1, 11: 1, 12: 1, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0}) -- \n
 

--- a/BinPy/examples/source/ic/Series_4000/IC4073.py
+++ b/BinPy/examples/source/ic/Series_4000/IC4073.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {2: 0, 3: 1, 4: 0, 5: 1, 7: 0, 9: 1, 10: 1, 11: 1, 12: 1, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0}) -- \n
 

--- a/BinPy/examples/source/ic/Series_4000/IC4075.py
+++ b/BinPy/examples/source/ic/Series_4000/IC4075.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 1, 2: 1, 3: 0, 4: 0, 5: 0, 7: 0, 8: 1, 11: 0, 12: 1, 13: 1, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0}) -- \n
 

--- a/BinPy/examples/source/ic/Series_4000/IC4077.py
+++ b/BinPy/examples/source/ic/Series_4000/IC4077.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 0, 2: 0, 5: 0, 6: 1, 7: 0, 8: 1, 9: 0, 12: 1, 13: 1, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0}) -- \n
 

--- a/BinPy/examples/source/ic/Series_4000/IC4078.py
+++ b/BinPy/examples/source/ic/Series_4000/IC4078.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {2: 0, 3: 0, 4: 0, 5: 0, 7: 0, 9: 0, 10: 0, 11: 0, 12: 0, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0}) -- \n
 

--- a/BinPy/examples/source/ic/Series_4000/IC4081.py
+++ b/BinPy/examples/source/ic/Series_4000/IC4081.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 0, 2: 0, 5: 0, 6: 1, 7: 0, 8: 1, 9: 0, 12: 1, 13: 1, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0}) -- \n
 

--- a/BinPy/examples/source/ic/Series_4000/IC4082.py
+++ b/BinPy/examples/source/ic/Series_4000/IC4082.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {2: 0, 3: 1, 4: 0, 5: 1, 7: 0, 9: 1, 10: 1, 11: 1, 12: 1, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7400.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7400.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 1, 2: 0, 4: 0, 5: 0, 7: 0, 9: 1, 10: 1, 12: 0, 13: 0, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7401.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7401.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {2: 0, 3: 0, 5: 0, 6: 1, 7: 0, 8: 1, 9: 1, 11: 1, 12: 1, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7402.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7402.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {2: 0, 3: 0, 5: 0, 6: 1, 7: 0, 8: 1, 9: 1, 11: 1, 12: 1, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7403.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7403.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 1, 2: 0, 4: 0, 5: 0, 7: 0, 9: 1, 10: 1, 12: 0, 13: 0, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7404.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7404.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 1, 3: 0, 5: 0, 7: 0, 9: 0, 11: 0, 13: 1, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7405.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7405.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 1, 2: 0, 4: 0, 5: 0, 7: 0, 9: 1, 10: 1, 12: 0, 13: 0, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7408.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7408.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 1, 2: 0, 4: 0, 5: 0, 7: 0, 9: 1, 10: 1, 12: 0, 13: 0, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7410.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7410.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 1, 2: 0, 3: 0, 4: 0, 5: 0, 7: 0, 9: 1, 10: 1, 11: 1, 13: 0, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7412.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7412.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 1, 2: 0, 3: 0, 4: 0, 5: 0, 7: 0, 9: 1, 10: 1, 11: 1, 13: 0, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7413.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7413.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 1, 2: 0, 4: 0, 5: 0, 7: 0, 9: 1, 10: 1, 12: 1, 13: 1, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC74138.py
+++ b/BinPy/examples/source/ic/Series_7400/IC74138.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 1, 2: 0, 3: 1, 4: 0, 5: 0, 6: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC74139.py
+++ b/BinPy/examples/source/ic/Series_7400/IC74139.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 0, 2: 0, 3: 0, 14: 0, 13: 1, 15: 0}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7415.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7415.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 1, 2: 0, 3: 0, 4: 0, 5: 0, 7: 0, 9: 1, 10: 1, 11: 1, 13: 0, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC74151A.py
+++ b/BinPy/examples/source/ic/Series_7400/IC74151A.py
@@ -36,7 +36,7 @@ inp = {
     14: 1,
     15: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC74152.py
+++ b/BinPy/examples/source/ic/Series_7400/IC74152.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 1, 2: 0, 3: 1, 4: 0, 5: 1, 8: 0, 9: 0, 10: 1, 11: 1, 12: 0, 13: 0}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC74153.py
+++ b/BinPy/examples/source/ic/Series_7400/IC74153.py
@@ -36,7 +36,7 @@ inp = {
     14: 0,
     15: 0}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC74156.py
+++ b/BinPy/examples/source/ic/Series_7400/IC74156.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 1, 2: 0, 3: 0, 13: 1, 8: 0, 16: 1, 15: 1, 14: 0}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7416.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7416.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 1, 2: 0, 3: 0, 4: 0, 5: 0, 7: 0, 9: 1, 10: 1, 11: 1, 13: 0, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7418.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7418.py
@@ -36,7 +36,7 @@ inp = {
     13: 1,
     14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7419.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7419.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 1, 2: 0, 3: 0, 4: 0, 5: 0, 7: 0, 9: 1, 10: 1, 11: 1, 13: 0, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7420.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7420.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 1, 2: 0, 4: 0, 5: 0, 7: 0, 9: 1, 10: 1, 12: 1, 13: 1, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7421.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7421.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 1, 2: 0, 4: 0, 5: 0, 7: 0, 9: 1, 10: 1, 12: 1, 13: 1, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7422.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7422.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 1, 2: 0, 4: 0, 5: 0, 7: 0, 9: 1, 10: 1, 12: 1, 13: 1, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7424.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7424.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 1, 2: 0, 4: 0, 5: 0, 7: 0, 9: 1, 10: 1, 12: 1, 13: 1, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7425.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7425.py
@@ -36,7 +36,7 @@ inp = {
     13: 1,
     14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7426.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7426.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 1, 2: 0, 4: 0, 5: 0, 7: 0, 9: 1, 10: 1, 12: 1, 13: 1, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7427.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7427.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 1, 2: 0, 3: 0, 4: 0, 5: 0, 7: 0, 9: 1, 10: 1, 11: 1, 13: 1, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7428.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7428.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 1, 2: 0, 4: 0, 5: 0, 7: 0, 9: 1, 10: 1, 12: 0, 13: 0, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7430.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7430.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 0, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1, 7: 0, 11: 1, 12: 1, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7431.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7431.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 1, 3: 1, 5: 0, 6: 0, 8: 0, 10: 1, 11: 1, 13: 0, 15: 1, 16: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7432.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7432.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 1, 2: 0, 4: 0, 5: 0, 7: 0, 9: 1, 10: 1, 12: 1, 13: 1, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7433.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7433.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {2: 0, 3: 0, 5: 0, 6: 0, 7: 0, 8: 1, 9: 1, 11: 1, 12: 1, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7437.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7437.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 1, 2: 0, 4: 0, 5: 0, 7: 0, 9: 1, 10: 1, 12: 1, 13: 1, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7440.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7440.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 1, 2: 0, 4: 0, 5: 0, 7: 0, 9: 1, 10: 1, 12: 1, 13: 1, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7442.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7442.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {8: 0, 12: 0, 13: 0, 14: 0, 15: 1, 16: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7443.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7443.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {8: 0, 12: 0, 13: 1, 14: 0, 15: 1, 16: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7444.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7444.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {8: 0, 12: 0, 13: 1, 14: 0, 15: 1, 16: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7445.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7445.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {8: 0, 12: 0, 13: 1, 14: 0, 15: 0, 16: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7451.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7451.py
@@ -36,7 +36,7 @@ inp = {
     13: 1,
     14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7454.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7454.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 1, 2: 0, 3: 0, 4: 0, 7: 0, 9: 1, 10: 1, 11: 0, 12: 0, 13: 0, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7455.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7455.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 1, 2: 0, 3: 0, 4: 0, 7: 0, 9: 1, 10: 1, 11: 0, 12: 0, 13: 0, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7458.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7458.py
@@ -36,7 +36,7 @@ inp = {
     13: 1,
     14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7464.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7464.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 1, 7: 0, 11: 1, 12: 1, 13: 1, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/ic/Series_7400/IC7486.py
+++ b/BinPy/examples/source/ic/Series_7400/IC7486.py
@@ -24,7 +24,7 @@ print(ic.__doc__)
 
 inp = {1: 1, 2: 0, 4: 0, 5: 0, 7: 0, 9: 1, 10: 1, 12: 0, 13: 0, 14: 1}
 
-# Pin initinalization
+# Pin initialization
 
 # Powering up the IC - using -- ic.setIC({14: 1, 7: 0})
 

--- a/BinPy/examples/source/sequential/Counters/DecadeCounter.py
+++ b/BinPy/examples/source/sequential/Counters/DecadeCounter.py
@@ -16,7 +16,7 @@ from BinPy.tools.oscilloscope import Oscilloscope
 
 # In[28]:
 
-# Initialize a toggle connectr for inpput in TFlipFlop
+# Initialize a toggle connectr for input in TFlipFlop
 
 toggle = Connector(1)
 

--- a/BinPy/examples/source/sequential/Counters/NBitDownCounter.py
+++ b/BinPy/examples/source/sequential/Counters/NBitDownCounter.py
@@ -15,7 +15,7 @@ from BinPy.tools.oscilloscope import Oscilloscope
 
 # In[2]:
 
-# Initialize a toggle connectr for inpput in TFlipFlop
+# Initialize a toggle connectr for input in TFlipFlop
 
 toggle = Connector(1)
 

--- a/BinPy/examples/source/sequential/Counters/NBitRippleCounter.py
+++ b/BinPy/examples/source/sequential/Counters/NBitRippleCounter.py
@@ -15,7 +15,7 @@ from BinPy.tools.oscilloscope import Oscilloscope
 
 # In[2]:
 
-# Initialize a toggle connectr for inpput in TFlipFlop
+# Initialize a toggle connectr for input in TFlipFlop
 
 toggle = Connector(1)
 

--- a/BinPy/examples/source/sequential/Counters/OctalCounter.py
+++ b/BinPy/examples/source/sequential/Counters/OctalCounter.py
@@ -15,7 +15,7 @@ from BinPy.tools.oscilloscope import Oscilloscope
 
 # In[2]:
 
-# Initialize a toggle connectr for inpput in TFlipFlop
+# Initialize a toggle connectr for input in TFlipFlop
 
 toggle = Connector(1)
 

--- a/BinPy/examples/source/sequential/Counters/Stage14Counter.py
+++ b/BinPy/examples/source/sequential/Counters/Stage14Counter.py
@@ -15,7 +15,7 @@ from BinPy.tools.oscilloscope import Oscilloscope
 
 # In[2]:
 
-# Initialize a toggle connectr for inpput in TFlipFlop
+# Initialize a toggle connectr for input in TFlipFlop
 
 toggle = Connector(1)
 

--- a/BinPy/ic/series_4000.py
+++ b/BinPy/ic/series_4000.py
@@ -1358,7 +1358,7 @@ class IC_4019(Base_16pin):
 class IC_4020(Base_16pin):
 
     """
-    CMOS 14 BIT asynchornous binary counter with reset
+    CMOS 14 BIT asynchronous binary counter with reset
     """
 
     def __init__(self):

--- a/BinPy/tests/test_bittools.py
+++ b/BinPy/tests/test_bittools.py
@@ -37,7 +37,7 @@ def test_bittools():
 
     try:
         bit_array_signed = BinPyBits(binary_string, 5, signed=False)
-        # This should hovever work
+        # This should however work
         assert True
     except:
         assert False

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ What is BinPy?
 ---------------
 BinPy is a digital electronics simulation library with a bunch of digital devices ( and a few experimental analog devices ) and tools / algorithms under its hood. BinPy is aimed towards students, helping them learn about digital logic in an interactive way. Being an open source project makes it easier for one to get an indepth understanding of the the underlying concepts by glossing at the source.
 
-BinPy focusses on the fundamentals. Everything has been written from scratch such as gates, logical operations, etc. 
+BinPy focuses on the fundamentals. Everything has been written from scratch such as gates, logical operations, etc. 
 
 Our future goals include a GUI tool to help easily build simple digital circuts and the implementation of the core using SPICE or equivalent tools for precise simulations.
 
@@ -88,7 +88,7 @@ from BinPy import *
 operator = Operations()
 operator.ADD(1011,11)
 operator.SUB(1011,11)
-operator.COMP('0011',1) #Second argument chooses betweem 1's or 2's Compliment
+operator.COMP('0011',1) #Second argument chooses between 1's or 2's Compliment
 
 
 # Combinational Logic

--- a/docs/source/examples/algorithms/expression_convert_example.rst
+++ b/docs/source/examples/algorithms/expression_convert_example.rst
@@ -1,5 +1,5 @@
 
-An example to demostrate functionality of ExpressionConvert.py
+An example to demonstrate functionality of ExpressionConvert.py
 --------------------------------------------------------------
 
 .. code:: python

--- a/docs/source/examples/algorithms/make_boolean_function_example.rst
+++ b/docs/source/examples/algorithms/make_boolean_function_example.rst
@@ -1,5 +1,5 @@
 
-An example to demostrate the usage of make boolean function.
+An example to demonstrate the usage of make boolean function.
 ------------------------------------------------------------
 
 .. code:: python


### PR DESCRIPTION
There are small typos in:
- BinPy/analog/buffers.py
- BinPy/analog/sig_gen.py
- BinPy/connectors/connector.py
- BinPy/connectors/linker.py
- BinPy/docs/ic/pin_class.md
- BinPy/examples/source/Gates/Connector.py
- BinPy/examples/source/algorithms/expression_convert_example.py
- BinPy/examples/source/algorithms/make_boolean_function_example.py
- BinPy/examples/source/analog/Analog Signal Generators.py
- BinPy/examples/source/connectors/Connector.py
- BinPy/examples/source/ic/Series_4000/IC4000.py
- BinPy/examples/source/ic/Series_4000/IC4001.py
- BinPy/examples/source/ic/Series_4000/IC4002.py
- BinPy/examples/source/ic/Series_4000/IC4011.py
- BinPy/examples/source/ic/Series_4000/IC4012.py
- BinPy/examples/source/ic/Series_4000/IC4023.py
- BinPy/examples/source/ic/Series_4000/IC4025.py
- BinPy/examples/source/ic/Series_4000/IC4068.py
- BinPy/examples/source/ic/Series_4000/IC4069.py
- BinPy/examples/source/ic/Series_4000/IC4070.py
- BinPy/examples/source/ic/Series_4000/IC4071.py
- BinPy/examples/source/ic/Series_4000/IC4072.py
- BinPy/examples/source/ic/Series_4000/IC4073.py
- BinPy/examples/source/ic/Series_4000/IC4075.py
- BinPy/examples/source/ic/Series_4000/IC4077.py
- BinPy/examples/source/ic/Series_4000/IC4078.py
- BinPy/examples/source/ic/Series_4000/IC4081.py
- BinPy/examples/source/ic/Series_4000/IC4082.py
- BinPy/examples/source/ic/Series_7400/IC7400.py
- BinPy/examples/source/ic/Series_7400/IC7401.py
- BinPy/examples/source/ic/Series_7400/IC7402.py
- BinPy/examples/source/ic/Series_7400/IC7403.py
- BinPy/examples/source/ic/Series_7400/IC7404.py
- BinPy/examples/source/ic/Series_7400/IC7405.py
- BinPy/examples/source/ic/Series_7400/IC7408.py
- BinPy/examples/source/ic/Series_7400/IC7410.py
- BinPy/examples/source/ic/Series_7400/IC7412.py
- BinPy/examples/source/ic/Series_7400/IC7413.py
- BinPy/examples/source/ic/Series_7400/IC74138.py
- BinPy/examples/source/ic/Series_7400/IC74139.py
- BinPy/examples/source/ic/Series_7400/IC7415.py
- BinPy/examples/source/ic/Series_7400/IC74151A.py
- BinPy/examples/source/ic/Series_7400/IC74152.py
- BinPy/examples/source/ic/Series_7400/IC74153.py
- BinPy/examples/source/ic/Series_7400/IC74156.py
- BinPy/examples/source/ic/Series_7400/IC7416.py
- BinPy/examples/source/ic/Series_7400/IC7418.py
- BinPy/examples/source/ic/Series_7400/IC7419.py
- BinPy/examples/source/ic/Series_7400/IC7420.py
- BinPy/examples/source/ic/Series_7400/IC7421.py
- BinPy/examples/source/ic/Series_7400/IC7422.py
- BinPy/examples/source/ic/Series_7400/IC7424.py
- BinPy/examples/source/ic/Series_7400/IC7425.py
- BinPy/examples/source/ic/Series_7400/IC7426.py
- BinPy/examples/source/ic/Series_7400/IC7427.py
- BinPy/examples/source/ic/Series_7400/IC7428.py
- BinPy/examples/source/ic/Series_7400/IC7430.py
- BinPy/examples/source/ic/Series_7400/IC7431.py
- BinPy/examples/source/ic/Series_7400/IC7432.py
- BinPy/examples/source/ic/Series_7400/IC7433.py
- BinPy/examples/source/ic/Series_7400/IC7437.py
- BinPy/examples/source/ic/Series_7400/IC7440.py
- BinPy/examples/source/ic/Series_7400/IC7442.py
- BinPy/examples/source/ic/Series_7400/IC7443.py
- BinPy/examples/source/ic/Series_7400/IC7444.py
- BinPy/examples/source/ic/Series_7400/IC7445.py
- BinPy/examples/source/ic/Series_7400/IC7451.py
- BinPy/examples/source/ic/Series_7400/IC7454.py
- BinPy/examples/source/ic/Series_7400/IC7455.py
- BinPy/examples/source/ic/Series_7400/IC7458.py
- BinPy/examples/source/ic/Series_7400/IC7464.py
- BinPy/examples/source/ic/Series_7400/IC7486.py
- BinPy/examples/source/sequential/Counters/DecadeCounter.py
- BinPy/examples/source/sequential/Counters/NBitDownCounter.py
- BinPy/examples/source/sequential/Counters/NBitRippleCounter.py
- BinPy/examples/source/sequential/Counters/OctalCounter.py
- BinPy/examples/source/sequential/Counters/Stage14Counter.py
- BinPy/ic/series_4000.py
- BinPy/tests/test_bittools.py
- README.md
- docs/source/examples/algorithms/expression_convert_example.rst
- docs/source/examples/algorithms/make_boolean_function_example.rst

Fixes:
- Should read `initialization` rather than `initinalization`.
- Should read `demonstrate` rather than `demostrate`.
- Should read `input` rather than `inpput`.
- Should read `returns` rather than `retuns`.
- Should read `instance` rather than `intance`.
- Should read `constraint` rather than `contraint`.
- Should read `service` rather than `servic`.
- Should read `truncated` rather than `trucated`.
- Should read `outputs` rather than `ouputs`.
- Should read `instances` rather than `intances`.
- Should read `however` rather than `hovever`.
- Should read `frequency` rather than `freqency`.
- Should read `focuses` rather than `focusses`.
- Should read `containing` rather than `containg`.
- Should read `collection` rather than `collecion`.
- Should read `between` rather than `betweem`.
- Should read `asynchronous` rather than `asynchornous`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md